### PR TITLE
Change filetype delimiter to .

### DIFF
--- a/rplugin/python3/deoppet/deoppet.py
+++ b/rplugin/python3/deoppet/deoppet.py
@@ -64,7 +64,7 @@ class Deoppet():
         if filetype in ft_snippets_map:
             fts = ft_snippets_map[filetype]
         else:
-            fts = filetype.split(',')
+            fts = filetype.split('.')
 
         snippets: typing.Dict[str, Snippet] = {}
         for dir in snippets_dirs:


### PR DESCRIPTION
Vim/Neovim uses "." as delimiter for filetypes instead of "," This is the same approach as Ultisnips. 

Let me know if you prefer this to be configurable and I will update the PR accordingly.